### PR TITLE
update deprecated kubernetes APIs

### DIFF
--- a/k8s_manifests/cloudbilling-prod_deployment.example.yml
+++ b/k8s_manifests/cloudbilling-prod_deployment.example.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: cloudbilling-prod
@@ -15,9 +15,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: cloud-billing
-          servicePort: 5000
+          service:
+            name: cloud-billing
+            port: 
+              number: 5000
         path: /
+        pathType: ImplementationSpecific
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/src/resources/k8s_cronjob.yaml
+++ b/src/resources/k8s_cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1 #kubernetes versions before 1.21.0 should use batch/v1beta1
 kind: CronJob
 metadata:
   name: $name


### PR DESCRIPTION
Kubernetes Documentation (Deprecated API Migration Guide): https://kubernetes.io/docs/reference/using-api/deprecation-guide/
- CronJob: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125
- Ingress: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122